### PR TITLE
fixed deprecation error

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var merge = require('merge');
 var makeArray = require('make-array');
 
 var SVGStore = require('broccoli-svgstore');
-var UnwatchedTree = require('broccoli-unwatched-tree');
+var broccoliSource = require('broccoli-source');
+var UnwatchedDir = broccoliSource.UnwatchedDir;
 var Funnel = require('broccoli-funnel');
 var MergeTrees = require('broccoli-merge-trees');
 
@@ -63,7 +64,9 @@ module.exports = {
   },
 
   _makeSourceTree: function(fileSpec) {
-    var inputs = makeArray(fileSpec.sourceDirs).map(UnwatchedTree);
+    var inputs = makeArray(fileSpec.sourceDirs).map((directoryPath) => {
+      return new UnwatchedDir(directoryPath);
+    });
     return this._maybeMerge(inputs, 'sources: ' + fileSpec.outputFile);
   },
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-svgstore": "^0.4.0",
-    "broccoli-unwatched-tree": "^0.1.1",
+    "broccoli-source": "^1.1.0",
     "make-array": "^1.0.1",
     "merge": "^1.2.0"
   }


### PR DESCRIPTION
The broccoli-unwatched-tree package has been deprecated and it broke the build of ember applications using this addon.

I fixed this by using the recommended package on the broccoli-unwatched-tree package README